### PR TITLE
Add CsCodeGeneration version from Unity project

### DIFF
--- a/LittleToySourceGenerator/CsCodeGenerator/AttributeModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/AttributeModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsCodeGenerator
+{
+    public class AttributeModel
+    {
+        public AttributeModel(string name = null)
+        {
+            this.Name = name;
+        }
+
+        public string Name { get; set; }
+
+        public List<Parameter> Parameters { get; set; } = new List<Parameter>();
+        public Parameter SingleParameter { set { Parameters.Add(value); } }
+
+        public override string ToString()
+        {
+            string parametersString = Parameters.Count > 0 ? Parameters.ToStringList() : "";
+            string result = $"[{Name}{parametersString}]";
+            return result;
+        }
+    }
+
+    public static class AttributeModelExtensions
+    {
+        public static string ToStringList(this List<AttributeModel> attributes, string indent)
+        {
+            string result = attributes.Count > 0 ? Util.NewLine + indent + String.Join(Util.NewLine + indent, attributes) : "";
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/BaseElement.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/BaseElement.cs
@@ -1,0 +1,57 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsCodeGenerator
+{
+    public abstract class BaseElement
+    {
+        public BaseElement() { }
+
+        public BaseElement(BuiltInDataType builtInDataType, string name)
+        {
+            this.BuiltInDataType = builtInDataType;
+            this.Name = name;
+        }
+
+        public BaseElement(string customDataType, string name)
+        {
+            this.CustomDataType = customDataType;
+            this.Name = name;
+        }
+
+        public virtual int IndentSize { get; set; } = (int)IndentType.Double * CsGenerator.DefaultTabSize;
+        public string Indent => new String(' ', IndentSize);
+
+        public virtual string Comment { get; set; }
+
+        public virtual bool HasAttributes => true;
+        public virtual List<AttributeModel> Attributes { get; set; } = new List<AttributeModel>();
+
+        public virtual AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+        protected string AccessFormated => Indent + AccessModifier.ToTextLower() + " ";
+
+        public List<KeyWord> KeyWords { get; set; } = new List<KeyWord>();
+        public KeyWord SingleKeyWord { set { KeyWords.Add(value); } }
+        protected string KeyWordsFormated => KeyWords?.Count > 0 ? String.Join(" ", KeyWords.Select(a => a.ToTextLower())) + " " : "";
+
+        public virtual BuiltInDataType? BuiltInDataType { get; set; }
+        public virtual string CustomDataType { get; set; }
+        protected string DataTypeFormated => CustomDataType ?? BuiltInDataType?.ToTextLower();
+
+        public virtual string Name { get; set; }
+
+        public virtual string Signature => $"{AccessFormated}{KeyWordsFormated}{DataTypeFormated} {Name}";
+
+        public void AddAttribute(AttributeModel attributeModel) => Attributes?.Add(attributeModel);
+
+        public override string ToString()
+        {
+            string result = Comment != null ? (Util.NewLine + Indent + "// " + Comment) : "";
+            result += HasAttributes ? Attributes.ToStringList(Indent) : "";
+            result += Util.NewLine + Signature;
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/ClassModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/ClassModel.cs
@@ -1,0 +1,81 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsCodeGenerator
+{
+    public class ClassModel : BaseElement
+    {
+        public ClassModel(string name = null)
+        {
+            base.CustomDataType = Util.Class;
+            base.Name = name;
+            Constructors.Add(new Constructor(Name) { IsVisible = false, BracesInNewLine = false });
+        }
+
+        public override int IndentSize { get; set; } = (int)IndentType.Single * CsGenerator.DefaultTabSize;
+
+        public bool HasPropertiesSpacing { get; set; } = true;
+
+        public new BuiltInDataType? BuiltInDataType { get; }
+
+        public new string CustomDataType => Util.Class;
+
+        public new string Name => base.Name;
+
+        public string BaseClass { get; set; }
+
+        public List<string> Interfaces { get; set; } = new List<string>();
+
+        public virtual List<Field> Fields { get; set; } = new List<Field>();
+
+        public virtual List<Constructor> Constructors { get; set; } = new List<Constructor>();
+
+        public virtual Constructor DefaultConstructor
+        {
+            get { return Constructors[0]; }
+            set { Constructors[0] = value; }
+        }
+
+        public virtual List<Property> Properties { get; set; } = new List<Property>();
+
+        public virtual List<Method> Methods { get; set; } = new List<Method>();
+
+        public virtual List<ClassModel> NestedClasses { get; set; } = new List<ClassModel>();
+        // Nested indent have to be set for each Nested element and subelement separately, or after generation manualy to select nested code and indent it with tab
+        // Setting it automaticaly and propagating could be done if the parent sets the child's parent reference (to itself) when the child is added/assigned to a parent. Parent setter is internal.
+        //   http://softwareengineering.stackexchange.com/questions/261453/what-is-the-best-way-to-initialize-a-childs-reference-to-its-parent
+
+        public override string ToString()
+        {
+            string result = base.ToString();
+            result += (BaseClass != null || Interfaces?.Count > 0) ? $" : " : "";
+            result += BaseClass != null ? BaseClass : "";
+            result += (BaseClass != null && Interfaces?.Count > 0) ? $", " : "";
+            result += Interfaces?.Count > 0 ? string.Join(", ", Interfaces) : "";
+            result += Util.NewLine + Indent + "{";
+
+            result += String.Join("", Fields);
+
+            var visibleConstructors = Constructors.Where(a => a.IsVisible);
+            bool hasFieldsBeforeConstructor = visibleConstructors.Any() && Fields.Any();
+            result += hasFieldsBeforeConstructor ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, visibleConstructors);
+            bool hasMembersAfterConstructor = (visibleConstructors.Any() || Fields.Any()) && (Properties.Any() || Methods.Any());
+            result += hasMembersAfterConstructor ? Util.NewLine : "";
+
+            result += String.Join(HasPropertiesSpacing ? Util.NewLine : "", Properties);
+
+            bool hasPropertiesAndMethods = Properties.Count > 0 && Methods.Count > 0;
+            result += hasMembersAfterConstructor ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, Methods);
+            
+            result += NestedClasses.Count > 0 ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, NestedClasses);
+
+            result += Util.NewLine + Indent + "}";
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Constructor.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Constructor.cs
@@ -1,0 +1,24 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class Constructor : Method
+    {
+        public Constructor(string name)
+        {
+            base.BuiltInDataType = null;
+            base.Name = name;
+        }
+        
+        public override bool IsVisible { get; set; } = true;
+
+        public new string Name => base.Name;
+
+        public new BuiltInDataType? BuiltInDataType => base.BuiltInDataType;
+        public new string CustomDataType => base.CustomDataType;
+
+        public override string Signature => AccessFormated + Name + Parameters.ToStringList();
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/CsGenerator.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/CsGenerator.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CsCodeGenerator
+{
+    // This is reduced version of https://github.com/borisdj/CsCodeGenerator/blob/master/CsCodeGenerator/CsGenerator.cs
+    // to make this code work in Roslyn context.
+    public class CsGenerator
+    {
+        public static int DefaultTabSize = 4;
+        public static string IndentSingle => new String(' ', CsGenerator.DefaultTabSize);
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/EnumModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/EnumModel.cs
@@ -1,0 +1,59 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class EnumModel : BaseElement
+    {
+        public EnumModel(string name = null)
+        {
+            base.CustomDataType = Util.Enum;
+            base.Name = name;
+        }
+
+        public override int IndentSize { get; set; } = (int)IndentType.Single * CsGenerator.DefaultTabSize;
+
+        public new BuiltInDataType? BuiltInDataType { get; }
+
+        public new string CustomDataType => base.CustomDataType;
+
+        public new string Name => base.Name;
+
+        public List<EnumValue> EnumValues { get; set; } = new List<EnumValue>();
+
+        public override string ToString()
+        {
+            string result = base.ToString();
+            result += Util.NewLine + Indent + "{";
+
+            result += EnumValues.Count > 0 ? Util.NewLine : "";
+            result += String.Join("," + Util.NewLine, EnumValues);
+            result += Util.NewLine + Indent + "}";
+            return result;
+        }
+    }
+
+    public class EnumValue
+    {
+        public EnumValue(string name = null, int? value = null)
+        {
+            this.Name = name;
+            this.Value = value;
+        }
+
+        public virtual int IndentSize { get; set; } = (int)IndentType.Double * CsGenerator.DefaultTabSize;
+        public string Indent => new String(' ', IndentSize);
+
+        public string Name { get; set; }
+
+        public int? Value { get; set; }
+        public string ValuFormated => Value != null ? " = " + Value : "";
+
+        public override string ToString()
+        {
+            string result = Indent + Name + ValuFormated;
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/AccessModifier.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/AccessModifier.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator.Enums
+{
+    public enum AccessModifier
+    {
+        Public,
+        Private,
+        Protected,
+        Internal,
+        Protected_Internal,
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/BuiltInDataType.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/BuiltInDataType.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator.Enums
+{
+    public enum BuiltInDataType
+    {
+        Void,
+        Bool,
+        Byte,
+        Int,
+        Long,
+        Decimal,
+        Float,
+        Double,
+        Char,
+        String,
+        Object
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/CommonDataType.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/CommonDataType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator.Enums
+{
+    public enum CommonDataType
+    {
+        DateTime,
+        Guid
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/EnumExtensions.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/EnumExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace CsCodeGenerator
+{
+    public static class EnumExtensions
+    {
+        /// <summary>
+        /// Convert string to Lowercase first, then replaces underscore '_' with space ' ', and  optionally adds append string.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value"></param>
+        /// <param name="append"></param>
+        /// <returns></returns>
+        public static string ToTextLower<T>(this T value, string append = "")
+        {
+            var result = value.ToString().ToLower().Replace("_", " ") + append;
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/IndentType.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/IndentType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public enum IndentType
+    {
+        None = 0,
+        Single = 1,
+        Double = 2,
+        Triple = 3,
+        Quadruple = 4,
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Enums/KeyWord.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Enums/KeyWord.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator.Enums
+{
+    public enum KeyWord
+    {
+        This,
+        Abstract,
+        Partial,
+        Static,
+        New,
+        Virtual,
+        Override,
+        Sealed,
+        Const,
+        Async
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Field.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Field.cs
@@ -1,0 +1,28 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class Field : BaseElement
+    {
+        public Field() { }
+
+        public Field(BuiltInDataType builtInDataType, string name) : base(builtInDataType, name) { }
+
+        public Field(string customDataType, string name) : base(customDataType, name) { }
+
+        public override AccessModifier AccessModifier { get; set; } = AccessModifier.Protected;
+
+        public virtual string Body { get; }
+
+        public virtual string DefaultValue { get; set; }
+        protected string DefaultValueFormated => DefaultValue != null ? " = " + DefaultValue : "";
+
+        public override bool HasAttributes => false;
+
+        protected virtual string Ending { get; } = ";";
+
+        public override string ToString() => base.ToString() + Body + DefaultValueFormated + Ending;
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/FileModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/FileModel.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class FileModel
+    {
+        public FileModel() { }
+        public FileModel(string name)
+        {
+            Name = name;
+        }
+
+        public List<string> UsingDirectives { get; set; } = new List<string>();
+
+        public string Namespace { get; set; }
+
+        public string Name { get; set; }
+
+        public string Extension { get; set; } = Util.CsExtension;
+
+        public string FullName => Name + "." + Extension;
+
+        public List<EnumModel> Enums { get; set; } = new List<EnumModel>();
+
+        public List<ClassModel> Classes { get; set; } = new List<ClassModel>();
+        
+        public List<StructModel> Structs { get; set; } = new List<StructModel>();
+        
+        public List<InterfaceModel> Interfaces { get; set; } = new List<InterfaceModel>();
+
+        public void LoadUsingDirectives(List<string> usingDirectives)
+        {
+            foreach (var usingDirective in usingDirectives)
+            {
+                UsingDirectives.Add(usingDirective);
+            }
+        }
+
+        public override string ToString()
+        {
+            string usingText = UsingDirectives.Count > 0 ? Util.Using + " " : "";
+            string result = usingText + String.Join(Util.NewLine + usingText, UsingDirectives);
+            //result += string.IsNullOrEmpty(Namespace) ? "" : Util.NewLineDouble + Util.Namespace + " " + Namespace;
+            //result += Util.NewLine + "{";
+            result += Util.NewLine;
+            result += String.Join(Util.NewLine, Enums);
+            result += (Enums.Count > 0 && Classes.Count > 0) ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, Classes);
+            result += (Classes.Count > 0 && Structs.Count > 0) ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, Structs);
+            result += (Structs.Count > 0 && Interfaces.Count > 0) ? Util.NewLine : "";
+            result += string.Join(Util.NewLine, Interfaces);
+            //result += Util.NewLine + "}";
+            result += Util.NewLine;
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/InterfaceModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/InterfaceModel.cs
@@ -1,0 +1,42 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class InterfaceModel : BaseElement
+    {
+        public InterfaceModel(string name = null)
+        {
+            base.CustomDataType = Util.Interface;
+            base.Name = name;
+        }
+
+        public override int IndentSize { get; set; } = (int)IndentType.Single * CsGenerator.DefaultTabSize;
+
+        public new BuiltInDataType? BuiltInDataType { get; }
+
+        public new string CustomDataType => base.CustomDataType;
+
+        public new string Name => base.Name;
+
+        public virtual List<Property> Properties { get; set; } = new List<Property>();
+
+        public virtual List<Method> Methods { get; set; } = new List<Method>();
+
+        public override string ToString()
+        {
+            string result = base.ToString();
+            result += Util.NewLine + Indent + "{";
+
+            result += String.Join("", Properties);
+            bool hasPropertiesAndMethods = Properties.Count > 0 && Methods.Count > 0;
+            result += hasPropertiesAndMethods ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, Methods);
+
+            result += Util.NewLine + Indent + "}";
+            result = result.Replace("\r\n        {\r\n        }", ";");
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Method.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Method.cs
@@ -1,0 +1,58 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class Method : BaseElement
+    {
+        public Method() { }
+
+        public Method(BuiltInDataType builtInDataType, string name) : base(builtInDataType, name) { }
+
+        public Method(string customDataType, string name) : base(customDataType, name) { }
+
+        public Method(AccessModifier accessModifier, KeyWord singleKeyWord, BuiltInDataType builtInDataType, string name) : base(builtInDataType, name)
+        {
+            this.AccessModifier = accessModifier;
+            this.KeyWords.Add(singleKeyWord);
+        }
+
+        public virtual bool IsVisible { get; set; } = true;
+
+        public List<Parameter> Parameters { get; set; } = new List<Parameter>();
+
+        public string BaseParameters { get; set; }
+        public string BaseParametersFormated => BaseParameters != null ? $" : base({BaseParameters})" : "";
+
+        public virtual bool BracesInNewLine { get; set; } = true;
+
+        public List<string> BodyLines { get; set; } = new List<string>();
+
+        public override string Signature => base.Signature + Parameters.ToStringList();
+
+        public bool WithoutBody = false;
+
+        public override string ToString()
+        {
+            if (!IsVisible)
+                return "";
+            string result = base.ToString() + BaseParametersFormated;
+            if (!WithoutBody)
+            {
+                string bracesPrefix = BracesInNewLine ? (Util.NewLine + Indent) : " ";
+                string curentIndent = Util.NewLine + Indent + CsGenerator.IndentSingle;
+                result += bracesPrefix + "{";
+                result += BodyLines.Count == 0
+                    ? ""
+                    : (BracesInNewLine ? curentIndent : " ") + String.Join(curentIndent, BodyLines);
+                result += bracesPrefix + "}";
+            }
+            else
+            {
+                result += ";";
+            }
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Parameter.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Parameter.cs
@@ -1,0 +1,55 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class Parameter
+    {
+        public Parameter() { }
+
+        public Parameter(string value)
+        {
+            this.Value = value;
+        }
+
+        public Parameter(BuiltInDataType builtInDataType, string name)
+        {
+            this.BuiltInDataType = builtInDataType;
+            this.Name = name;
+        }
+
+        public Parameter(string customDataType, string name)
+        {
+            this.CustomDataType = customDataType;
+            this.Name = name;
+        }
+        public KeyWord? KeyWord { get; set; }
+
+        public BuiltInDataType? BuiltInDataType { get; set; }
+
+        public string CustomDataType { get; set; }
+
+        public string Name { get; set; }
+
+        public string Value { get; set; }
+
+        public string KeyWordFormated => KeyWord?.ToTextLower(" ");
+
+        public string DataTypeFormated => CustomDataType == null ? BuiltInDataType?.ToTextLower(" ") : CustomDataType + " ";
+
+        public string NameValueFormated => (String.IsNullOrEmpty(Name) || String.IsNullOrEmpty(Value)) ? Name + Value : Name + " = " + Value;
+
+        public override string ToString() => KeyWordFormated + DataTypeFormated + NameValueFormated;
+    }
+
+    public static class ParameterExtensions
+    {
+        public static string ToStringList(this List<Parameter> parameters)
+        {
+            string parametersString = String.Join(", ", parameters);
+            string result = $"({parametersString})";
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Property.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Property.cs
@@ -1,0 +1,69 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+
+namespace CsCodeGenerator
+{
+    public class Property : Field
+    {
+        public Property() { }
+
+        public Property(BuiltInDataType builtInDataType, string name) : base(builtInDataType, name) { }
+
+        public Property(string customDataType, string name) : base(customDataType, name) { }
+
+        public override bool HasAttributes => true;
+
+        public override AccessModifier AccessModifier { get; set; } = AccessModifier.Public;
+
+        public bool IsGetOnly { get; set; } = false;
+        public bool IsExpressBody { get; set; } = false;
+        
+        public bool IsAutoImplemented { get; set; } = true;
+        
+        public string GetterBody { get; set; }
+
+        public string SetterBody { get; set; }
+
+        protected override string Ending => DefaultValue != null ? ";" : "";
+
+        public override string Body
+        {
+            get
+            {
+                if (IsAutoImplemented)
+                {
+                    return IsGetOnly? " { get; }" : " { get; set; }";
+                }
+                else if (IsExpressBody)
+                {
+                    string result = Util.NewLine + Indent + "{";
+                    string curentIndent = Util.NewLine + Indent + CsGenerator.IndentSingle;
+
+                    result += curentIndent + "get => " + GetterBody + ";";
+                    if (!IsGetOnly && SetterBody != null)
+                    {
+                        result += curentIndent + "set => " + SetterBody + ";";
+                    }
+                    result += Util.NewLine + Indent + "}";
+                    
+                    return result;
+                }
+                else
+                {
+                    string result = Util.NewLine + Indent + "{";
+                    string curentIndent = Util.NewLine + Indent + CsGenerator.IndentSingle;
+
+                    result += curentIndent + "get { return " + GetterBody + "; }";
+                    if (!IsGetOnly && SetterBody != null)
+                    {
+                        result += curentIndent + "set { " + SetterBody + "; }";
+                    }
+                    result += Util.NewLine + Indent + "}";
+
+                    return result;
+                }
+            } 
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/StructModel.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/StructModel.cs
@@ -1,0 +1,81 @@
+using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CsCodeGenerator
+{
+    public class StructModel : BaseElement
+    {
+        public StructModel(string name = null)
+        {
+            base.CustomDataType = Util.Struct;
+            base.Name = name;
+            Constructors.Add(new Constructor(Name) { IsVisible = false, BracesInNewLine = false });
+        }
+
+        public override int IndentSize { get; set; } = (int)IndentType.Single * CsGenerator.DefaultTabSize;
+
+        public bool HasPropertiesSpacing { get; set; } = true;
+
+        public new BuiltInDataType? BuiltInDataType { get; }
+
+        public new string CustomDataType => Util.Struct;
+
+        public new string Name => base.Name;
+
+        public string BaseClass { get; set; }
+
+        public List<string> Interfaces { get; set; } = new List<string>();
+
+        public virtual List<Field> Fields { get; set; } = new List<Field>();
+
+        public virtual List<Constructor> Constructors { get; set; } = new List<Constructor>();
+
+        public virtual Constructor DefaultConstructor
+        {
+            get { return Constructors[0]; }
+            set { Constructors[0] = value; }
+        }
+
+        public virtual List<Property> Properties { get; set; } = new List<Property>();
+
+        public virtual List<Method> Methods { get; set; } = new List<Method>();
+
+        public virtual List<ClassModel> NestedClasses { get; set; } = new List<ClassModel>();
+        // Nested indent have to be set for each Nested element and subelement separately, or after generation manualy to select nested code and indent it with tab
+        // Setting it automaticaly and propagating could be done if the parent sets the child's parent reference (to itself) when the child is added/assigned to a parent. Parent setter is internal.
+        //   http://softwareengineering.stackexchange.com/questions/261453/what-is-the-best-way-to-initialize-a-childs-reference-to-its-parent
+
+        public override string ToString()
+        {
+            string result = base.ToString();
+            result += (BaseClass != null || Interfaces?.Count > 0) ? $" : " : "";
+            result += BaseClass != null ? BaseClass : "";
+            result += (BaseClass != null && Interfaces?.Count > 0) ? $", " : "";
+            result += Interfaces?.Count > 0 ? string.Join(", ", Interfaces) : "";
+            result += Util.NewLine + Indent + "{";
+
+            result += String.Join("", Fields);
+
+            var visibleConstructors = Constructors.Where(a => a.IsVisible);
+            bool hasFieldsBeforeConstructor = visibleConstructors.Any() && Fields.Any();
+            result += hasFieldsBeforeConstructor ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, visibleConstructors);
+            bool hasMembersAfterConstructor = (visibleConstructors.Any() || Fields.Any()) && (Properties.Any() || Methods.Any());
+            result += hasMembersAfterConstructor ? Util.NewLine : "";
+
+            result += String.Join(HasPropertiesSpacing ? Util.NewLine : "", Properties);
+
+            bool hasPropertiesAndMethods = Properties.Count > 0 && Methods.Count > 0;
+            result += hasMembersAfterConstructor ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, Methods);
+            
+            result += NestedClasses.Count > 0 ? Util.NewLine : "";
+            result += String.Join(Util.NewLine, NestedClasses);
+
+            result += Util.NewLine + Indent + "}";
+            return result;
+        }
+    }
+}

--- a/LittleToySourceGenerator/CsCodeGenerator/Util.cs
+++ b/LittleToySourceGenerator/CsCodeGenerator/Util.cs
@@ -1,0 +1,31 @@
+﻿using CsCodeGenerator.Enums;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace CsCodeGenerator
+{
+    public static class Util
+    {
+        public static string Using = "using";
+        public static string Namespace = "namespace";
+        public static string Class = "class";
+        public static string Struct = "struct";
+        public static string Enum = "enum";
+        public static string Interface = "interface";
+        public static string Base = "base";
+        public static string CsExtension = "cs";
+        public static string TxtExtension = "txt";
+        public static string NewLine = System.Environment.NewLine;
+        public static string NewLineDouble = NewLine + NewLine;
+
+        public static string LowerFirst(this string s)
+        {
+            if (s != string.Empty && char.IsUpper(s[0]))
+            {
+                s =  char.ToLower(s[0]) + s.Substring(1);
+            }
+            return s;
+        }
+    }
+}


### PR DESCRIPTION
The only difference between https://github.com/LTBTCOOEOS/RoslynTestProject/blob/develop/Assets/Plugins/basegame/Generator/Editor/Models/CsGenerator.cs
is that I remove all specifics which is related to Unity. For example CreateFiles is not nescessary since it would be done using Roslyn now.