### PR TITLE
Add missing Unity.Collections namespace

### DIFF
--- a/LittleToySourceGenerator.Tests/GenerateEventSystemTests.cs
+++ b/LittleToySourceGenerator.Tests/GenerateEventSystemTests.cs
@@ -42,6 +42,7 @@ public partial class TransformView : LinkedView
 #nullable enable
 #pragma warning disable 1591
 using System;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Plugins.basegame.Events;
@@ -193,6 +194,7 @@ public partial class TransformView : LinkedView
 #nullable enable
 #pragma warning disable 1591
 using System;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Plugins.basegame.Events;
@@ -342,6 +344,7 @@ public partial class TransformView : LinkedView
 #nullable enable
 #pragma warning disable 1591
 using System;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Plugins.basegame.Events;
@@ -452,6 +455,7 @@ public partial class TransformView : LinkedView
 #nullable enable
 #pragma warning disable 1591
 using System;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Plugins.basegame.Events;
@@ -563,6 +567,7 @@ public partial class TransformView : LinkedView
 #nullable enable
 #pragma warning disable 1591
 using System;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Plugins.basegame.Events;

--- a/LittleToySourceGenerator/LittleToySourceGenerator.cs
+++ b/LittleToySourceGenerator/LittleToySourceGenerator.cs
@@ -687,6 +687,7 @@ public class Generator : ISourceGenerator
         var usingDirectives = new List<string>
         {
             "System;",
+            "Unity.Collections;",
             "Unity.Entities;",
             "Unity.Mathematics;",
             "Plugins.basegame.Events;",


### PR DESCRIPTION
This namespace was needed for ReadOnly attribute.
Poor me!